### PR TITLE
Implement Memory Manipulation on Windows

### DIFF
--- a/site-packages/serpent/window_controller.py
+++ b/site-packages/serpent/window_controller.py
@@ -31,23 +31,23 @@ class WindowController:
     def get_window_geometry(self, window_id):
         return self.adapter.get_window_geometry(window_id)
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-
         Address: Hex value, find using Cheat Engine
         Size: Number of bytes, usually 4 but if not just copy whatever works in CE
         Pointer Offsets: A list of hex memory pointer offsets, find using Cheat Engine. If empty, will assume address is not a pointer
-        Add Handle: Used to update the address when game is restarted, will almost always be true
+        Add Base: Adds the base address of the program. Used to update the address when game is restarted, will almost always be true
         Allow Partial: Doesn't throw an error if the memory can only be paritially read
 
         -Output-
         Value: Binary representation of the memory's value, use int.from_bytes() or similar method to convert
         '''
 
-        return self.adapter.read_memory(address, size, pointer_offsets, add_handle, allow_partial)
+        return self.adapter.read_memory(address, size, pointer_offsets, add_base, allow_partial)
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-
@@ -55,11 +55,11 @@ class WindowController:
         Address: Hex value, find using Cheat Engine
         Size: Number of bytes, usually 4 but if not just copy whatever works in CE
         Pointer Offsets: A list of hex memory pointer offsets, find using Cheat Engine. If empty, will assume address is not a pointer
-        Add Handle: Used to update the address when game is restarted, will almost always be true
+        Add Base: Adds the base address of the program. Used to update the address when game is restarted, will almost always be true
         Allow Partial: Doesn't throw an error if the memory can only be paritially written
         '''
 
-        self.adapter.write_memory(value, address, size, pointer_offsets, add_handle, allow_partial)
+        self.adapter.write_memory(value, address, size, pointer_offsets, add_base, allow_partial)
 
     def _load_adapter(self):
         if is_linux():

--- a/site-packages/serpent/window_controller.py
+++ b/site-packages/serpent/window_controller.py
@@ -31,7 +31,7 @@ class WindowController:
     def get_window_geometry(self, window_id):
         return self.adapter.get_window_geometry(window_id)
 
-    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-
@@ -44,9 +44,9 @@ class WindowController:
         Value: Binary representation of the memory's value, use int.from_bytes() or similar method to convert
         '''
 
-        return self.adapter.read_memory(address, size, add_handle, allow_partial)
+        return self.adapter.read_memory(address, size, pointer_offsets, add_handle, allow_partial)
 
-    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-
@@ -57,7 +57,7 @@ class WindowController:
         Allow Partial: Doesn't throw an error if the memory can only be paritially written
         '''
 
-        self.adapter.write_memory(value, address, size, add_handle, allow_partial)
+        self.adapter.write_memory(value, address, size, pointer_offsets, add_handle, allow_partial)
 
     def _load_adapter(self):
         if is_linux():

--- a/site-packages/serpent/window_controller.py
+++ b/site-packages/serpent/window_controller.py
@@ -31,6 +31,34 @@ class WindowController:
     def get_window_geometry(self, window_id):
         return self.adapter.get_window_geometry(window_id)
 
+    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+        '''Currently only implemented on Windows.
+
+        -Inputs-
+        Address: Hex value, find using Cheat Engine
+        Size: Number of bytes, usually 4 but if not just copy whatever works in CE
+        Add Handle: Used if the address is something like '[Game].exe+FFFFFF'
+        Allow Partial: Doesn't throw an error if the memory can only be paritially read
+
+        -Output-
+        Value: Binary representation of the memory's value, use int.from_bytes() or similar method to convert
+        '''
+
+        return self.adapter.read_memory(address, size, add_handle, allow_partial)
+
+    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+        '''Currently only implemented on Windows.
+
+        -Inputs-
+        Value: Binary representation of the memory's value, use int.to_bytes() or similar method to convert
+        Address: Hex value, find using Cheat Engine
+        Size: Number of bytes, usually 4 but if not just copy whatever works in CE
+        Add Handle: Used if the address is something like '[Game].exe+FFFFFF'
+        Allow Partial: Doesn't throw an error if the memory can only be paritially written
+        '''
+
+        self.adapter.write_memory(value, address, size, add_handle, allow_partial)
+
     def _load_adapter(self):
         if is_linux():
             from serpent.window_controllers.linux_window_controller import LinuxWindowController

--- a/site-packages/serpent/window_controller.py
+++ b/site-packages/serpent/window_controller.py
@@ -31,7 +31,7 @@ class WindowController:
     def get_window_geometry(self, window_id):
         return self.adapter.get_window_geometry(window_id)
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-
@@ -46,7 +46,7 @@ class WindowController:
 
         return self.adapter.read_memory(address, size, pointer_offsets, add_handle, allow_partial)
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         '''Currently only implemented on Windows.
 
         -Inputs-

--- a/site-packages/serpent/window_controller.py
+++ b/site-packages/serpent/window_controller.py
@@ -37,7 +37,8 @@ class WindowController:
         -Inputs-
         Address: Hex value, find using Cheat Engine
         Size: Number of bytes, usually 4 but if not just copy whatever works in CE
-        Add Handle: Used if the address is something like '[Game].exe+FFFFFF'
+        Pointer Offsets: A list of hex memory pointer offsets, find using Cheat Engine. If empty, will assume address is not a pointer
+        Add Handle: Used to update the address when game is restarted, will almost always be true
         Allow Partial: Doesn't throw an error if the memory can only be paritially read
 
         -Output-
@@ -53,7 +54,8 @@ class WindowController:
         Value: Binary representation of the memory's value, use int.to_bytes() or similar method to convert
         Address: Hex value, find using Cheat Engine
         Size: Number of bytes, usually 4 but if not just copy whatever works in CE
-        Add Handle: Used if the address is something like '[Game].exe+FFFFFF'
+        Pointer Offsets: A list of hex memory pointer offsets, find using Cheat Engine. If empty, will assume address is not a pointer
+        Add Handle: Used to update the address when game is restarted, will almost always be true
         Allow Partial: Doesn't throw an error if the memory can only be paritially written
         '''
 

--- a/site-packages/serpent/window_controllers/darwin_window_controller.py
+++ b/site-packages/serpent/window_controllers/darwin_window_controller.py
@@ -67,8 +67,8 @@ class DarwinWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/darwin_window_controller.py
+++ b/site-packages/serpent/window_controllers/darwin_window_controller.py
@@ -67,8 +67,8 @@ class DarwinWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/darwin_window_controller.py
+++ b/site-packages/serpent/window_controllers/darwin_window_controller.py
@@ -66,3 +66,9 @@ class DarwinWindowController(WindowController):
         geometry["y_offset"] = int(window_information[1])
 
         return geometry
+
+    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+        raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
+
+    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+        raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/darwin_window_controller.py
+++ b/site-packages/serpent/window_controllers/darwin_window_controller.py
@@ -67,8 +67,8 @@ class DarwinWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/linux_window_controller.py
+++ b/site-packages/serpent/window_controllers/linux_window_controller.py
@@ -45,3 +45,9 @@ class LinuxWindowController(WindowController):
         geometry["y_offset"] = int(re.match(r"\s+Absolute upper-left Y:\s+([0-9]+)", window_information.split("\n")[3]).group(1))
 
         return geometry
+
+    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+        raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
+
+    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+        raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/linux_window_controller.py
+++ b/site-packages/serpent/window_controllers/linux_window_controller.py
@@ -46,8 +46,8 @@ class LinuxWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/linux_window_controller.py
+++ b/site-packages/serpent/window_controllers/linux_window_controller.py
@@ -46,8 +46,8 @@ class LinuxWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/linux_window_controller.py
+++ b/site-packages/serpent/window_controllers/linux_window_controller.py
@@ -46,8 +46,8 @@ class LinuxWindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")
 
-    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         raise NotImplementedError("Memory manipulation is currently only supported on Windows.")

--- a/site-packages/serpent/window_controllers/win32_window_controller.py
+++ b/site-packages/serpent/window_controllers/win32_window_controller.py
@@ -7,6 +7,8 @@ import win32process
 import ctypes
 from ctypes import wintypes
 
+import sys
+
 # Importing pyautogui to fix frame extractor - this makes it extract the window size correctly
 # See https://github.com/Martyn0324/SerpentAI/issues/3 for further information
 import pyautogui
@@ -81,11 +83,16 @@ class Win32WindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
 
         if add_handle:
             address += self.handle
+
+        if pointer_offsets != None:
+            for offset in pointer_offsets:
+                read_address = int.from_bytes(self.read_memory(address, add_handle=False), sys.byteorder)
+                address = read_address + offset
 
         # Creates buffer to store data in
         buf = (ctypes.c_char * size)()
@@ -98,13 +105,17 @@ class Win32WindowController(WindowController):
                 raise
         return buf[:nread.value]
 
-    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
         WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
         GetLastError = ctypes.windll.kernel32.GetLastError
 
-
         if add_handle:
             address += self.handle
+
+        if pointer_offsets != None:
+            for offset in pointer_offsets:
+                read_address = int.from_bytes(self.read_memory(address, add_handle=False), sys.byteorder)
+                address = read_address + offset
 
         # Creates buffer to store data in
         buf = (ctypes.c_char * size)()

--- a/site-packages/serpent/window_controllers/win32_window_controller.py
+++ b/site-packages/serpent/window_controllers/win32_window_controller.py
@@ -1,18 +1,47 @@
 from serpent.window_controller import WindowController
 
 import win32gui
+import win32api
+import win32process
+
+import ctypes
+from ctypes import wintypes
 
 # Importing pyautogui to fix frame extractor - this makes it extract the window size correctly
 # See https://github.com/Martyn0324/SerpentAI/issues/3 for further information
 import pyautogui
 
+# Defines required Windows access rights.
+PROCESS_VM_READ = 0x0010
+PROCESS_VM_WRITE = 0x0020
+PROCESS_VM_OPERATION = 0x0008
+
+# Index for pulling a window handle.
+GWLP_HINSTANCE = -6
+
+SIZE_T = ctypes.c_size_t
+
 class Win32WindowController(WindowController):
 
     def __init__(self):
-        pass
+        self.window_id = None
+        self.process_id = None
+        self.handle = None
+        self.hProcess = None
 
     def locate_window(self, name):
-        return win32gui.FindWindow(None, name)
+        OpenProcess = ctypes.windll.kernel32.OpenProcess
+
+        self.window_id = win32gui.FindWindow(None, name)
+
+        # Gets neccesary data for memory reading
+        self.process_id = (win32process.GetWindowThreadProcessId(self.window_id))[1]
+        self.handle = win32api.GetWindowLong(self.window_id, GWLP_HINSTANCE)
+
+        # Opens a process handle to the target application
+        self.hProcess = OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION, False, self.process_id)
+
+        return self.window_id
 
     def move_window(self, window_id, x, y):
         x0, y0, x1, y1 = win32gui.GetWindowRect(window_id)
@@ -51,3 +80,45 @@ class Win32WindowController(WindowController):
         geometry["y_offset"] = y0 + (y1 - y0 - height - border_width)
 
         return geometry
+
+    def read_memory(self, address, size=4, add_handle=False, allow_partial=False):
+        ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
+
+        if add_handle:
+            address += self.handle
+
+        # Creates buffer to store data in
+        buf = (ctypes.c_char * size)()
+        nread = SIZE_T()
+
+        try:
+            ReadProcessMemory(self.hProcess, address, buf, size, ctypes.byref(nread))
+        except WindowsError as e:
+            if not allow_partial or e.winerror != ERROR_PARTIAL_COPY:
+                raise
+        return buf[:nread.value]
+
+    def write_memory(self, value, address, size=4, add_handle=False, allow_partial=False):
+        WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
+        GetLastError = ctypes.windll.kernel32.GetLastError
+
+
+        if add_handle:
+            address += self.handle
+
+        # Creates buffer to store data in
+        buf = (ctypes.c_char * size)()
+        nread = SIZE_T()
+
+
+        # Writes value to buffer
+        for i, val in enumerate(value):
+            buf[i] = val
+
+        try:
+            write = WriteProcessMemory(self.hProcess, address, buf, size, ctypes.byref(nread))
+        except WindowsError as e:
+            if not allow_partial or e.winerror != ERROR_PARTIAL_COPY:
+                raise
+        if write == 0:
+            raise Exception('Unable to write to memory.', ctypes.FormatError(GetLastError()))

--- a/site-packages/serpent/window_controllers/win32_window_controller.py
+++ b/site-packages/serpent/window_controllers/win32_window_controller.py
@@ -83,7 +83,7 @@ class Win32WindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
 
         if add_handle:
@@ -105,7 +105,7 @@ class Win32WindowController(WindowController):
                 raise
         return buf[:nread.value]
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=False, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
         WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
         GetLastError = ctypes.windll.kernel32.GetLastError
 

--- a/site-packages/serpent/window_controllers/win32_window_controller.py
+++ b/site-packages/serpent/window_controllers/win32_window_controller.py
@@ -83,15 +83,15 @@ class Win32WindowController(WindowController):
 
         return geometry
 
-    def read_memory(self, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def read_memory(self, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
 
-        if add_handle:
+        if add_base:
             address += self.handle
 
         if pointer_offsets != None:
             for offset in pointer_offsets:
-                read_address = int.from_bytes(self.read_memory(address, add_handle=False), sys.byteorder)
+                read_address = int.from_bytes(self.read_memory(address, add_base=False), sys.byteorder)
                 address = read_address + offset
 
         # Creates buffer to store data in
@@ -105,16 +105,16 @@ class Win32WindowController(WindowController):
                 raise
         return buf[:nread.value]
 
-    def write_memory(self, value, address, size=4, pointer_offsets=None, add_handle=True, allow_partial=False):
+    def write_memory(self, value, address, size=4, pointer_offsets=None, add_base=True, allow_partial=False):
         WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
         GetLastError = ctypes.windll.kernel32.GetLastError
 
-        if add_handle:
+        if add_base:
             address += self.handle
 
         if pointer_offsets != None:
             for offset in pointer_offsets:
-                read_address = int.from_bytes(self.read_memory(address, add_handle=False), sys.byteorder)
+                read_address = int.from_bytes(self.read_memory(address, add_base=False), sys.byteorder)
                 address = read_address + offset
 
         # Creates buffer to store data in

--- a/site-packages/serpent/window_controllers/win32_window_controller.py
+++ b/site-packages/serpent/window_controllers/win32_window_controller.py
@@ -63,9 +63,6 @@ class Win32WindowController(WindowController):
     def get_focused_window_name(self):
         return win32gui.GetWindowText(win32gui.GetForegroundWindow())
 
-# This function is probably the one causing the problem. Maybe replacing win32gui
-# for pygetwindow could solve this
-
     def get_window_geometry(self, window_id):
         geometry = dict()
 


### PR DESCRIPTION
Using OCR to pull data seems like both a pain to setup and rather inefficient, plus it doesn't work on all data types one may want to use from a game. Implementing the ability to easily read from the program's memory fixes these issues, and depending on the game it may allow one to forgo capturing the screen entirely, avoiding the need for a CNN.

Writing to memory is less obviously useful, however it can assist in setting up the game into a certain state for training.